### PR TITLE
Баг с двойной кодировкой

### DIFF
--- a/Models/QHFMessage.cs
+++ b/Models/QHFMessage.cs
@@ -12,37 +12,37 @@ public class QHFMessage
 
     public DateTime Time { get; set; }
 
-    public short MsgBlockType { get; set; }
+    // public short MsgBlockType { get; set; }
+    //
+    // public bool SignatureMismatch => Signature != 1;
 
-    public bool SignatureMismatch => Signature != 1;
+    // public bool Equals(IcqMessage msg)
+    // {
+    //     if (msg.IsMy == IsMy)
+    //         if (DateTimeEquals(msg.DateTime, Time))
+    //             return true;
+    //
+    //     return false;
+    // }
 
-    public bool Equals(IcqMessage msg)
-    {
-        if (msg.IsMy == IsMy)
-            if (DateTimeEquals(msg.DateTime, Time))
-                return true;
-
-        return false;
-    }
-
-    /// <summary>
-    ///     Сранивает две даты вплоть до секунды, поскольку большая точность не имеет значения в контексте ICQ сообщения.
-    /// </summary>
-    /// <param name="dt1">Первый из сравниваемых объектов.</param>
-    /// <param name="dt2">Второй из сравниваемых объектов.</param>
-    /// <returns></returns>
-    public static bool DateTimeEquals(DateTime dt1, DateTime dt2)
-    {
-        if (dt1.Year == dt2.Year)
-            if (dt1.Month == dt2.Month)
-                if (dt1.Date == dt2.Date)
-                    if (dt1.Hour == dt2.Hour)
-                        if (dt1.Minute == dt2.Minute)
-                            if (dt1.Second == dt2.Second)
-                                return true;
-
-        return false;
-    }
+    // /// <summary>
+    // ///     Сранивает две даты вплоть до секунды, поскольку большая точность не имеет значения в контексте ICQ сообщения.
+    // /// </summary>
+    // /// <param name="dt1">Первый из сравниваемых объектов.</param>
+    // /// <param name="dt2">Второй из сравниваемых объектов.</param>
+    // /// <returns></returns>
+    // public static bool DateTimeEquals(DateTime dt1, DateTime dt2)
+    // {
+    //     if (dt1.Year == dt2.Year)
+    //         if (dt1.Month == dt2.Month)
+    //             if (dt1.Date == dt2.Date)
+    //                 if (dt1.Hour == dt2.Hour)
+    //                     if (dt1.Minute == dt2.Minute)
+    //                         if (dt1.Second == dt2.Second)
+    //                             return true;
+    //
+    //     return false;
+    // }
 
     public override string ToString()
     {

--- a/Models/QHFVersion.cs
+++ b/Models/QHFVersion.cs
@@ -1,0 +1,8 @@
+namespace QIParser.Models;
+
+public enum QHFVersion : byte
+{
+    Unknown = 1,
+    Qip2010 = 2,
+    QipInfiumOrHigher = 3
+}

--- a/Program.cs
+++ b/Program.cs
@@ -15,6 +15,7 @@ Console.WriteLine(Directory.GetCurrentDirectory());
 Console.WriteLine("Введите адрес папки, которая содержит файлы истории (*.AHF, *.BHD, *.QHF):");
 var historyFolderPath = //Console.ReadLine();
     "/Users/new_omega/dev";
+Console.WriteLine(historyFolderPath);
 
 if (string.IsNullOrEmpty(historyFolderPath) || !Directory.Exists(historyFolderPath))
 {
@@ -24,6 +25,7 @@ if (string.IsNullOrEmpty(historyFolderPath) || !Directory.Exists(historyFolderPa
 
 Console.Write("Искать файлы во вложенных папках? [Y/N]: N");
 var searchOption = SearchOption.TopDirectoryOnly;
+Console.WriteLine();
 
 //if (Console.ReadLine()?.ToLower() == "y") searchOption = SearchOption.AllDirectories;
 
@@ -43,6 +45,7 @@ do
     Console.Write("Введите ваш ник: ");
     userName = //Console.ReadLine();
         "new_omega";
+    Console.WriteLine(userName);
 } while (string.IsNullOrEmpty(userName));
 
 Console.WriteLine("Введите адрес папки, куда будут сохранены сконвертированные файлы истории:");
@@ -86,14 +89,14 @@ void ConvertFile(string fileName, string outputFolderPath, string userName)
     using var fs = new FileStream(outputFileName, FileMode.Create);
     using var sw = new StreamWriter(fs, Encoding.UTF8);
 
-    HistoryWriter.WriteHeader(sw.WriteLine, reader);
+    HistoryWriter.WriteHeader(Console.WriteLine, reader);
 
     var msg = new QHFMessage();
 
     while (reader.GetNextMessage(msg))
     {
         HistoryWriter.WriteBody(sw.WriteLine, msg, userName, reader.Nick);
-        Console.WriteLine(msg.Text);
+        //Console.WriteLine(msg.Text);
     }
 
     Console.WriteLine(outputFileName);

--- a/Program.cs
+++ b/Program.cs
@@ -14,7 +14,8 @@ Console.WriteLine(Directory.GetCurrentDirectory());
 
 Console.WriteLine("Введите адрес папки, которая содержит файлы истории (*.AHF, *.BHD, *.QHF):");
 var historyFolderPath = //Console.ReadLine();
-    "/Users/new_omega/dev";
+    @"C:\Users\Selecty\Documents\QIP Infium\[qhf]";
+    //@"C:\Users\Selecty\Documents\QIParser Output";
 Console.WriteLine(historyFolderPath);
 
 if (string.IsNullOrEmpty(historyFolderPath) || !Directory.Exists(historyFolderPath))
@@ -50,7 +51,7 @@ do
 
 Console.WriteLine("Введите адрес папки, куда будут сохранены сконвертированные файлы истории:");
 var outputFolderPath = //Console.ReadLine();
-    "/Users/new_omega/dev";
+    @"C:\Users\Selecty\Documents\QIParser Output";
 
 if (string.IsNullOrEmpty(outputFolderPath) || !Directory.Exists(outputFolderPath))
 {

--- a/Program.cs
+++ b/Program.cs
@@ -10,8 +10,11 @@ QIParser, версия 1.0.0.
 Описание: Конвертер файлов истории из QIP и QIP Infium. Преобразует файл с историей в TXT-файл в кодировке UFT-8.
 ");
 
+Console.WriteLine(Directory.GetCurrentDirectory());
+
 Console.WriteLine("Введите адрес папки, которая содержит файлы истории (*.AHF, *.BHD, *.QHF):");
-var historyFolderPath = Console.ReadLine();
+var historyFolderPath = //Console.ReadLine();
+    "/Users/new_omega/dev";
 
 if (string.IsNullOrEmpty(historyFolderPath) || !Directory.Exists(historyFolderPath))
 {
@@ -19,10 +22,10 @@ if (string.IsNullOrEmpty(historyFolderPath) || !Directory.Exists(historyFolderPa
     return;
 }
 
-Console.Write("Искать файлы во вложенных папках? [Y/N]:");
+Console.Write("Искать файлы во вложенных папках? [Y/N]: N");
 var searchOption = SearchOption.TopDirectoryOnly;
 
-if (Console.ReadLine()?.ToLower() == "y") searchOption = SearchOption.AllDirectories;
+//if (Console.ReadLine()?.ToLower() == "y") searchOption = SearchOption.AllDirectories;
 
 var historyFiles = Directory.GetFiles(historyFolderPath, "*.?hf", searchOption);
 
@@ -38,11 +41,13 @@ var userName = string.Empty;
 do
 {
     Console.Write("Введите ваш ник: ");
-    userName = Console.ReadLine();
+    userName = //Console.ReadLine();
+        "new_omega";
 } while (string.IsNullOrEmpty(userName));
 
 Console.WriteLine("Введите адрес папки, куда будут сохранены сконвертированные файлы истории:");
-var outputFolderPath = Console.ReadLine();
+var outputFolderPath = //Console.ReadLine();
+    "/Users/new_omega/dev";
 
 if (string.IsNullOrEmpty(outputFolderPath) || !Directory.Exists(outputFolderPath))
 {
@@ -85,7 +90,11 @@ void ConvertFile(string fileName, string outputFolderPath, string userName)
 
     var msg = new QHFMessage();
 
-    while (reader.GetNextMessage(msg)) HistoryWriter.WriteBody(sw.WriteLine, msg, userName, reader.Nick);
+    while (reader.GetNextMessage(msg))
+    {
+        HistoryWriter.WriteBody(sw.WriteLine, msg, userName, reader.Nick);
+        Console.WriteLine(msg.Text);
+    }
 
     Console.WriteLine(outputFileName);
 }

--- a/Program.cs
+++ b/Program.cs
@@ -14,8 +14,9 @@ Console.WriteLine(Directory.GetCurrentDirectory());
 
 Console.WriteLine("Введите адрес папки, которая содержит файлы истории (*.AHF, *.BHD, *.QHF):");
 var historyFolderPath = //Console.ReadLine();
+    // @"C:\Users\Selecty\Documents\QIP Infium\badddd";
     @"C:\Users\Selecty\Documents\QIP Infium\[qhf]";
-    //@"C:\Users\Selecty\Documents\QIParser Output";
+
 Console.WriteLine(historyFolderPath);
 
 if (string.IsNullOrEmpty(historyFolderPath) || !Directory.Exists(historyFolderPath))
@@ -51,7 +52,7 @@ do
 
 Console.WriteLine("Введите адрес папки, куда будут сохранены сконвертированные файлы истории:");
 var outputFolderPath = //Console.ReadLine();
-    @"C:\Users\Selecty\Documents\QIParser Output";
+    historyFolderPath;
 
 if (string.IsNullOrEmpty(outputFolderPath) || !Directory.Exists(outputFolderPath))
 {
@@ -59,7 +60,7 @@ if (string.IsNullOrEmpty(outputFolderPath) || !Directory.Exists(outputFolderPath
     return;
 }
 
-outputFolderPath = Path.Combine(outputFolderPath.TrimEnd(Path.DirectorySeparatorChar), $"Конвертация {DateTime.Now:ddMMyyyy_HHmmss}");
+//outputFolderPath = Path.Combine(outputFolderPath.TrimEnd(Path.DirectorySeparatorChar), $"Конвертация {DateTime.Now:ddMMyyyy_HHmmss}");
 Directory.CreateDirectory(outputFolderPath);
 
 foreach (var fileName in historyFiles)
@@ -70,6 +71,7 @@ foreach (var fileName in historyFiles)
     catch (Exception e)
     {
         Console.WriteLine("Ошибка при конвертации файла:");
+        Console.WriteLine(e);
         Console.WriteLine(fileName);
     }
 

--- a/Program.cs
+++ b/Program.cs
@@ -5,9 +5,9 @@ using System.Text;
 Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
 
 Console.WriteLine(@"
-QIParser, версия 1.0.0. 
+QIParser, версия 1.1.0. 
 Автор: Константин Комаров.
-Описание: Конвертер файлов истории из QIP и QIP Infium. Преобразует файл с историей в TXT-файл в кодировке UFT-8.
+Описание: Конвертер файлов истории QIP и QIP Infium. Преобразует файл с историей в TXT-файл в кодировке UFT-8.
 ");
 
 Console.WriteLine("Введите адрес папки, которая содержит файлы истории (*.AHF, *.BHD, *.QHF):");

--- a/Program.cs
+++ b/Program.cs
@@ -10,12 +10,8 @@ QIParser, версия 1.0.0.
 Описание: Конвертер файлов истории из QIP и QIP Infium. Преобразует файл с историей в TXT-файл в кодировке UFT-8.
 ");
 
-Console.WriteLine(Directory.GetCurrentDirectory());
-
 Console.WriteLine("Введите адрес папки, которая содержит файлы истории (*.AHF, *.BHD, *.QHF):");
 var historyFolderPath = Console.ReadLine();
-
-Console.WriteLine(historyFolderPath);
 
 if (string.IsNullOrEmpty(historyFolderPath) || !Directory.Exists(historyFolderPath))
 {
@@ -23,7 +19,7 @@ if (string.IsNullOrEmpty(historyFolderPath) || !Directory.Exists(historyFolderPa
     return;
 }
 
-Console.Write("Искать файлы во вложенных папках? [Y/N]: N");
+Console.Write("Искать файлы во вложенных папках? [Y/N]: ");
 var searchOption = SearchOption.TopDirectoryOnly;
 Console.WriteLine();
 
@@ -47,7 +43,6 @@ do
 {
     Console.Write("Введите ваш ник: ");
     userName = Console.ReadLine();
-    Console.WriteLine(userName);
 } while (string.IsNullOrEmpty(userName));
 
 Console.WriteLine("Введите адрес папки, куда будут сохранены сконвертированные файлы истории:");
@@ -90,14 +85,13 @@ void ConvertFile(string fileName, string outputFolderPath, string userName)
     using var fs = new FileStream(outputFileName, FileMode.Create);
     using var sw = new StreamWriter(fs, Encoding.UTF8);
 
-    HistoryWriter.WriteHeader(Console.WriteLine, reader);
+    HistoryWriter.WriteHeader(sw.WriteLine, reader);
 
     var msg = new QHFMessage();
 
     while (reader.GetNextMessage(msg))
     {
         HistoryWriter.WriteBody(sw.WriteLine, msg, userName, reader.Nick);
-        //Console.WriteLine(msg.Text);
     }
 
     Console.WriteLine(outputFileName);

--- a/Program.cs
+++ b/Program.cs
@@ -13,9 +13,7 @@ QIParser, версия 1.0.0.
 Console.WriteLine(Directory.GetCurrentDirectory());
 
 Console.WriteLine("Введите адрес папки, которая содержит файлы истории (*.AHF, *.BHD, *.QHF):");
-var historyFolderPath = //Console.ReadLine();
-    // @"C:\Users\Selecty\Documents\QIP Infium\badddd";
-    @"C:\Users\Selecty\Documents\QIP Infium\[qhf]";
+var historyFolderPath = Console.ReadLine();
 
 Console.WriteLine(historyFolderPath);
 
@@ -29,7 +27,10 @@ Console.Write("Искать файлы во вложенных папках? [Y/
 var searchOption = SearchOption.TopDirectoryOnly;
 Console.WriteLine();
 
-//if (Console.ReadLine()?.ToLower() == "y") searchOption = SearchOption.AllDirectories;
+if (Console.ReadLine()?.ToLower() == "y")
+{
+    searchOption = SearchOption.AllDirectories;
+}
 
 var historyFiles = Directory.GetFiles(historyFolderPath, "*.?hf", searchOption);
 
@@ -45,14 +46,12 @@ var userName = string.Empty;
 do
 {
     Console.Write("Введите ваш ник: ");
-    userName = //Console.ReadLine();
-        "new_omega";
+    userName = Console.ReadLine();
     Console.WriteLine(userName);
 } while (string.IsNullOrEmpty(userName));
 
 Console.WriteLine("Введите адрес папки, куда будут сохранены сконвертированные файлы истории:");
-var outputFolderPath = //Console.ReadLine();
-    historyFolderPath;
+var outputFolderPath = Console.ReadLine();
 
 if (string.IsNullOrEmpty(outputFolderPath) || !Directory.Exists(outputFolderPath))
 {
@@ -60,7 +59,7 @@ if (string.IsNullOrEmpty(outputFolderPath) || !Directory.Exists(outputFolderPath
     return;
 }
 
-//outputFolderPath = Path.Combine(outputFolderPath.TrimEnd(Path.DirectorySeparatorChar), $"Конвертация {DateTime.Now:ddMMyyyy_HHmmss}");
+outputFolderPath = Path.Combine(outputFolderPath.TrimEnd(Path.DirectorySeparatorChar), $"Конвертация {DateTime.Now:ddMMyyyy_HHmmss}");
 Directory.CreateDirectory(outputFolderPath);
 
 foreach (var fileName in historyFiles)
@@ -71,7 +70,6 @@ foreach (var fileName in historyFiles)
     catch (Exception e)
     {
         Console.WriteLine("Ошибка при конвертации файла:");
-        Console.WriteLine(e);
         Console.WriteLine(fileName);
     }
 

--- a/QHFReader.cs
+++ b/QHFReader.cs
@@ -111,8 +111,6 @@ public class QHFReader : IDisposable
 
         var diff = end - start;
 
-        Debug.WriteLine($"Размер блока сообщения ({blockSize}) = Размер самого сообщения ({msgSize}) + размер QHFRecord (33, {diff}) - 6");
-
         // Почему 6 -- неизвестно
         var check = msgSize + diff - 6;
         if (check != blockSize)

--- a/QHFReader.cs
+++ b/QHFReader.cs
@@ -14,18 +14,40 @@ public class QHFReader : IDisposable
     {
         fs = new FileStream(path, FileMode.Open);
         br = new BinaryReaderBE(fs, encoding);
+        
+        // Заголовок
+        Console.WriteLine("Чтение заголовка");
 
-        fs.Position = 4;
+        var sign = string.Concat(br.ReadChars(3));
+        if (sign != "QHF")
+        {
+            Console.WriteLine($"Signature mismatch! Expected 'QHF', got '{sign}'");
+        }
+        var version = (QHFVersion) br.ReadByte();
+        Console.WriteLine($"History file version: {version.ToString()}");
+        
+        //fs.Position = 4;
         Size = br.ReadInt32();
-        fs.Position = 34;
+        var unknown1 = br.ReadBytes(10);
+        var unknown2 = br.ReadBytes(16);
+        // fs.Position = 34;
         MsgCount = br.ReadInt32();
-        fs.Position = 44;
+        var msgCount = br.ReadInt32();
+        if (MsgCount != msgCount)
+        {
+            Console.WriteLine($"Количество сообщений не совпадает!\nОжидаемое {msgCount}, реальное {MsgCount}.");
+        }
+
+        var reserved = br.ReadInt16();
+        
+        Console.WriteLine("Заголовок ОК");
+        
+        // fs.Position = 44;
+        // Блок данных UIN и Nickname
         var uinLength = br.ReadInt16();
         Uin = encoding.GetString(br.ReadBytes(uinLength));
         var nickLength = br.ReadInt16();
-
         //var bytes = br.ReadBytes(nickLength);
-        
         Nick = encoding.GetString(br.ReadBytes(nickLength));
     }
 
@@ -69,6 +91,8 @@ public class QHFReader : IDisposable
                 return true;
             }
         }
+        
+        
 
         var size = br.ReadInt32();
         var endOfBlock = size + fs.Position;

--- a/QHFReader.cs
+++ b/QHFReader.cs
@@ -65,6 +65,32 @@ public class QHFReader : IDisposable
         fs.Close();
     }
 
+    public void ReadQip2010(QHFMessage msg)
+    {
+        msg.Signature = br.ReadInt16();
+        var blockSize = br.ReadInt32();
+
+        // Тип поля с id сообщения - Всегда 1
+        var fieldType = br.ReadInt16();
+        // Размер поля - всегда 4
+        var fieldSize = br.ReadInt16();
+        // Номер сообщения
+        var id = br.ReadInt32();
+        // Тип поля с датой сообщения - всегда 2
+        fieldType = br.ReadInt16();
+        // Размер поля -- всегда 4
+        fieldSize = br.ReadInt16();
+        // Дата и время отправки в Unix time
+        var time = br.ReadInt32();
+        // Тип поля с ?? - всегда 3
+        fieldType = br.ReadInt16();
+        // ??? -- всегда 3
+        fieldSize = br.ReadInt16();
+        // Входящее или исходящее
+        var isMy = br.ReadBoolean();
+
+    }
+    
     public bool GetNextMessage(QHFMessage msg)
     {
         if (fs.Position >= fs.Length - 24)

--- a/QHFReader.cs
+++ b/QHFReader.cs
@@ -9,6 +9,15 @@ public class QHFReader : IDisposable
     private readonly Encoding encoding = Encoding.UTF8;
 
     private readonly FileStream fs;
+    public string Nick { get; set; }
+
+    public string Uin { get; set; }
+
+    public int MsgCount { get; set; }
+
+    public int Size { get; set; }
+
+    public QHFVersion Version { get; init; }
 
     public QHFReader(string path)
     {
@@ -21,24 +30,29 @@ public class QHFReader : IDisposable
         var sign = string.Concat(br.ReadChars(3));
         if (sign != "QHF")
         {
-            Console.WriteLine($"Signature mismatch! Expected 'QHF', got '{sign}'");
+            Console.WriteLine($"Подпись не совпадает! Ожидаемая QHF, реальная {sign}");
         }
-        var version = (QHFVersion) br.ReadByte();
-        Console.WriteLine($"History file version: {version.ToString()}");
+        Version = (QHFVersion) br.ReadByte();
+        Console.WriteLine($"Версия файла истории: {Version.ToString()}");
         
         //fs.Position = 4;
         Size = br.ReadInt32();
-        var unknown1 = br.ReadBytes(10);
-        var unknown2 = br.ReadBytes(16);
+        // Неизвестно
+        br.ReadBytes(10);
+        // Неизвестно
+        br.ReadBytes(16);
         // fs.Position = 34;
+        // Количество сообщений
         MsgCount = br.ReadInt32();
-        var msgCount = br.ReadInt32();
-        if (MsgCount != msgCount)
+        // Количество сообщений -- сверка
+        var msgCountToVerify = br.ReadInt32();
+        if (MsgCount != msgCountToVerify)
         {
-            Console.WriteLine($"Количество сообщений не совпадает!\nОжидаемое {msgCount}, реальное {MsgCount}.");
+            Console.WriteLine($"Количество сообщений не совпадает!\nОжидаемое {msgCountToVerify}, реальное {MsgCount}.");
         }
 
-        var reserved = br.ReadInt16();
+        // Зарезервировано
+        br.ReadInt16();
         
         Console.WriteLine("Заголовок ОК");
         
@@ -51,166 +65,280 @@ public class QHFReader : IDisposable
         Nick = encoding.GetString(br.ReadBytes(nickLength));
     }
 
-    public string Nick { get; set; }
-
-    public string Uin { get; set; }
-
-    public int MsgCount { get; set; }
-
-    public int Size { get; set; }
-
-    public void Dispose()
+    private void ReadQip2010(QHFMessage msg)
     {
-        br.Close();
-        fs.Close();
+        var start = fs.Position;
+
+        msg.Signature = br.ReadInt16();
+        var blockSize = br.ReadInt32();
+
+        // Тип поля с id сообщения - Всегда 1
+        var fieldType = br.ReadInt16();
+        // Размер поля - всегда 4
+        var fieldSize = br.ReadInt16();
+        // Номер сообщения
+        msg.ID = br.ReadInt32();
+        // Тип поля с датой сообщения - всегда 2
+        fieldType = br.ReadInt16();
+        // Размер поля -- всегда 4
+        fieldSize = br.ReadInt16();
+        // Дата и время отправки в Unix time
+        var time = br.ReadInt32();
+        msg.Time = UnixTimeStampToDateTime(time);
+
+        // Тип поля с ?? - всегда 3
+        fieldType = br.ReadInt16();
+        // ??? -- всегда 3
+        fieldSize = br.ReadInt16();
+        // Входящее или исходящее
+        msg.IsMy = br.ReadBoolean();
+        // Тип поля = 0x0f
+        fieldType = br.ReadInt16();
+        // Размер поля = 0x04  
+        fieldSize = br.ReadInt16();
+        // Размер самого сообщения  
+        var msgSize = br.ReadInt16();
+        var end = fs.Position;
+        var text = br.ReadBytes(msgSize);
+
+        DecodeBytes(text);
+        // DecodeBytes(text);
+
+        msg.Text = encoding.GetString(text);
+
+        var diff = end - start;
+
+        //Console.WriteLine($"Размер блока сообщения ({blockSize}) = Размер самого сообщения ({msgSize}) + размер QHFRecord (33, {diff}) - 6 ");
+
+        var check = msgSize + diff - 6;
+
+        if (check != blockSize)
+        {
+            Console.WriteLine($"Размер блока не совпадает (ожидал {blockSize}, получил {check})");
+        }
     }
 
-    public void ReadQip2010(QHFMessage msg)
+    private void ReadQipInfium(QHFMessage msg)
     {
-        while (true)
+        var start = fs.Position;
+
+        msg.Signature = br.ReadInt16();
+        var blockSize = br.ReadInt32();
+
+        // Тип поля с id сообщения - Всегда 1
+        var fieldType = br.ReadInt16();
+        // Размер поля - всегда 4
+        var fieldSize = br.ReadInt16();
+        // Номер сообщения
+        msg.ID = br.ReadInt32();
+        // Тип поля с датой сообщения - всегда 2
+        fieldType = br.ReadInt16();
+        // Размер поля -- всегда 4
+        fieldSize = br.ReadInt16();
+        // Дата и время отправки в Unix time
+        var time = br.ReadInt32();
+        msg.Time = UnixTimeStampToDateTime(time);
+
+        // Тип поля с ?? - всегда 3
+        fieldType = br.ReadInt16();
+        // ??? -- всегда 3
+        fieldSize = br.ReadInt16();
+        // Входящее или исходящее
+        msg.IsMy = br.ReadBoolean();
+        // Тип поля = 0x0f
+        fieldType = br.ReadInt16();
+        // Размер поля = 0x04  
+        fieldSize = br.ReadInt16();
+        // Размер самого сообщения  
+        var msgSize = br.ReadInt32();
+        var end = fs.Position;
+        var text = br.ReadBytes(msgSize);
+
+        DecodeBytes(text);
+
+        msg.Text = encoding.GetString(text);
+
+        var diff = end - start;
+
+        //Console.WriteLine($"Размер блока сообщения ({blockSize}) = Размер самого сообщения ({msgSize}) + размер QHFRecord (33, {diff}) - 6 ");
+
+        var check = msgSize + diff - 6;
+
+        if (check != blockSize)
         {
-            var start = fs.Position;
-
-            msg.Signature = br.ReadInt16();
-            var blockSize = br.ReadInt32();
-
-            // Тип поля с id сообщения - Всегда 1
-            var fieldType = br.ReadInt16();
-            // Размер поля - всегда 4
-            var fieldSize = br.ReadInt16();
-            // Номер сообщения
-            var id = br.ReadInt32();
-            // Тип поля с датой сообщения - всегда 2
-            fieldType = br.ReadInt16();
-            // Размер поля -- всегда 4
-            fieldSize = br.ReadInt16();
-            // Дата и время отправки в Unix time
-            var time = br.ReadInt32();
-            var timeHuman = UnixTimeStampToDateTime(time);
-
-            // Тип поля с ?? - всегда 3
-            fieldType = br.ReadInt16();
-            // ??? -- всегда 3
-            fieldSize = br.ReadInt16();
-            // Входящее или исходящее
-            var isMy = br.ReadBoolean();
-            // Тип поля = 0x0f
-            fieldType = br.ReadInt16();
-            // Размер поля = 0x04  
-            fieldSize = br.ReadInt16();
-            // Размер самого сообщения  
-            var msgSize = br.ReadInt16();
-            var end = fs.Position;
-            var text = br.ReadBytes(msgSize);
-
-            DecodeBytes(text);
-
-            var textDecoded = encoding.GetString(text);
-
-            var diff = end - start;
-            
-            //Console.WriteLine($"Размер блока сообщения ({blockSize}) = Размер самого сообщения ({msgSize}) + размер QHFRecord (33, {diff}) - 6 ");
-
-            var check = msgSize + diff - 6;
-
-            if (check != blockSize)
-            {
-                Console.WriteLine($"Размер блока не совпадает (ожидал {blockSize}, получил {check})");
-            }
+            Console.WriteLine($"Размер блока не совпадает (ожидал {blockSize}, получил {check})");
         }
-
     }
     
+    private void ReadQipUnknown(QHFMessage msg)
+    {
+        var start = fs.Position;
+
+        msg.Signature = br.ReadInt16();
+        var blockSize = br.ReadInt32();
+
+        // Тип поля с id сообщения - Всегда 1
+        var fieldType = br.ReadInt16();
+        // Размер поля - всегда 4
+        var fieldSize = br.ReadInt16();
+        // Номер сообщения
+        msg.ID = br.ReadInt32();
+        // Тип поля с датой сообщения - всегда 2
+        fieldType = br.ReadInt16();
+        // Размер поля -- всегда 4
+        fieldSize = br.ReadInt16();
+        // Дата и время отправки в Unix time
+        var time = br.ReadInt32();
+        msg.Time = UnixTimeStampToDateTime(time);
+
+        // Тип поля с ?? - всегда 3
+        fieldType = br.ReadInt16();
+        // ??? -- всегда 3
+        fieldSize = br.ReadInt16();
+        // Входящее или исходящее
+        msg.IsMy = br.ReadBoolean();
+        // Тип поля = 0x0f
+        fieldType = br.ReadInt16();
+        // Размер поля = 0x04  
+        fieldSize = br.ReadInt16();
+        // Размер самого сообщения  
+        var msgSize = br.ReadInt16();
+        var end = fs.Position;
+        var text = br.ReadBytes(msgSize);
+
+        DecodeBytes(text);
+        DecodeBytes(text);
+
+        msg.Text = encoding.GetString(text);
+
+        var diff = end - start;
+
+        //Console.WriteLine($"Размер блока сообщения ({blockSize}) = Размер самого сообщения ({msgSize}) + размер QHFRecord (33, {diff}) - 6 ");
+
+        var check = msgSize + diff - 6;
+
+        if (check != blockSize)
+        {
+            Console.WriteLine($"Размер блока не совпадает (ожидал {blockSize}, получил {check})");
+        }
+    }
+
     public bool GetNextMessage(QHFMessage msg)
     {
-        ReadQip2010(msg);
-
-        if (fs.Position >= fs.Length - 24)
+        if (fs.Position == fs.Length)
         {
             return false;
         }
 
-        byte[] msgBytes = null;
-        //Trace.WriteLine("Block start: " + fs.Position);
-        msg.Signature = br.ReadInt16();
-
-        if (msg.SignatureMismatch)
-        {
-            if (br.ReadByte() == 1)
-            {
-                // В предыдущем сообщении были ошибки и структура съехала.
-                msg.Signature = 1;
-            }
-            else
-            {
-                // Сдвигаем позицию на исходную для достоверности отладки.
-                fs.Position -= 1;
-                Console.WriteLine($"{Uin} ({Nick}). Signature mismatch. (sign={msg.Signature})");
-                return true;
-            }
-        }
-        
-        
-
-        var size = br.ReadInt32();
-        var endOfBlock = size + fs.Position;
-
         try
         {
-            // QIP 2010
-            var fieldType = br.ReadInt16();
-            var fieldSize = br.ReadInt16();
-            var id = br.ReadInt32();
-            fieldType = br.ReadInt16();
-            fieldSize = br.ReadInt16();
-            var time = br.ReadInt32();
-            
-            
-            
-            msg.ID = GetNextBlock();
-            msg.Time = UnixTimeStampToDateTime(GetNextBlock());
-            msg.IsMy = GetNextBlock() > 0;
-            var msgLength = GetNextBlock();
-
-            if (msgLength < 0)
+            switch (Version)
             {
-                fs.Position -= 4;
-                msgBytes = ReadBytesUntilNextMessage(msg.ID + 1);
-                msgLength = msgBytes.Length;
+                case QHFVersion.Qip2010:
+                    ReadQip2010(msg);
+                    break;
+                case QHFVersion.QipInfiumOrHigher:
+                    ReadQipInfium(msg);
+                    break;
+                case QHFVersion.Unknown:
+                    ReadQipUnknown(msg);
+                    break;
             }
-            else
-            {
-                if (msgLength > size)
-                {
-                    fs.Position -= 4;
-                    msgLength = br.ReadInt16();
-
-                    if (msgLength > size)
-                    {
-                        fs.Position -= 2;
-                        msgLength = br.ReadByte();
-                    }
-                }
-
-                msgBytes = br.ReadBytes(msgLength);
-            }
-
-            DecodeBytes(msgBytes);
-            DecodeBytes(msgBytes);
-
-            msg.Text = encoding.GetString(msgBytes);
-
-            return true;
         }
-        catch (ArgumentException ex)
+        catch (Exception ex)
         {
-            Console.WriteLine(ex.Message);
-            if (fs.Position == fs.Length)
-            {
-                msg.Text = "Сообщение потеряно.";
-            }
-            return true;
+            var position = fs.Position;
+            var lentgh = fs.Length;
         }
+
+        return true;
+
+        // if (fs.Position >= fs.Length - 24)
+        // {
+        //     return false;
+        // }
+        //
+        // byte[] msgBytes = null;
+        // //Trace.WriteLine("Block start: " + fs.Position);
+        // msg.Signature = br.ReadInt16();
+        //
+        // if (msg.SignatureMismatch)
+        // {
+        //     if (br.ReadByte() == 1)
+        //     {
+        //         // В предыдущем сообщении были ошибки и структура съехала.
+        //         msg.Signature = 1;
+        //     }
+        //     else
+        //     {
+        //         // Сдвигаем позицию на исходную для достоверности отладки.
+        //         fs.Position -= 1;
+        //         Console.WriteLine($"{Uin} ({Nick}). Signature mismatch. (sign={msg.Signature})");
+        //         return true;
+        //     }
+        // }
+
+
+
+        // var size = br.ReadInt32();
+        // var endOfBlock = size + fs.Position;
+        //
+        // try
+        // {
+        //     // QIP 2010
+        //     var fieldType = br.ReadInt16();
+        //     var fieldSize = br.ReadInt16();
+        //     var id = br.ReadInt32();
+        //     fieldType = br.ReadInt16();
+        //     fieldSize = br.ReadInt16();
+        //     var time = br.ReadInt32();
+        //     
+        //     
+        //     
+        //     msg.ID = GetNextBlock();
+        //     msg.Time = UnixTimeStampToDateTime(GetNextBlock());
+        //     msg.IsMy = GetNextBlock() > 0;
+        //     var msgLength = GetNextBlock();
+        //
+        //     if (msgLength < 0)
+        //     {
+        //         fs.Position -= 4;
+        //         msgBytes = ReadBytesUntilNextMessage(msg.ID + 1);
+        //         msgLength = msgBytes.Length;
+        //     }
+        //     else
+        //     {
+        //         if (msgLength > size)
+        //         {
+        //             fs.Position -= 4;
+        //             msgLength = br.ReadInt16();
+        //
+        //             if (msgLength > size)
+        //             {
+        //                 fs.Position -= 2;
+        //                 msgLength = br.ReadByte();
+        //             }
+        //         }
+        //
+        //         msgBytes = br.ReadBytes(msgLength);
+        //     }
+        //
+        //     DecodeBytes(msgBytes);
+        //     DecodeBytes(msgBytes);
+        //
+        //     msg.Text = encoding.GetString(msgBytes);
+        //
+        //     return true;
+        // }
+        // catch (ArgumentException ex)
+        // {
+        //     Console.WriteLine(ex.Message);
+        //     if (fs.Position == fs.Length)
+        //     {
+        //         msg.Text = "Сообщение потеряно.";
+        //     }
+        //     return true;
+        // }
     }
 
     public int GetSize(short size)
@@ -304,5 +432,12 @@ public class QHFReader : IDisposable
     {
         var dateTime = new DateTime(1970, 1, 1);
         return dateTime.AddSeconds(unixTimeStamp);
+    }
+
+
+    public void Dispose()
+    {
+        br.Close();
+        fs.Close();
     }
 }

--- a/QHFReader.cs
+++ b/QHFReader.cs
@@ -99,6 +99,16 @@ public class QHFReader : IDisposable
 
         try
         {
+            // QIP 2010
+            var fieldType = br.ReadInt16();
+            var fieldSize = br.ReadInt16();
+            var id = br.ReadInt32();
+            fieldType = br.ReadInt16();
+            fieldSize = br.ReadInt16();
+            var time = br.ReadInt32();
+            
+            
+            
             msg.ID = GetNextBlock();
             msg.Time = UnixTimeStampToDateTime(GetNextBlock());
             msg.IsMy = GetNextBlock() > 0;

--- a/Utils/BinaryReaderBE.cs
+++ b/Utils/BinaryReaderBE.cs
@@ -20,7 +20,6 @@ public class BinaryReaderBE : BinaryReader
     public BinaryReaderBE(Stream input)
         : base(input)
     {
-        new BinaryReader(input);
     }
 
     /// <summary>
@@ -80,4 +79,10 @@ public class BinaryReaderBE : BinaryReader
         Array.Reverse(data);
         return BitConverter.ToUInt64(data, 0);
     }
+
+    // алиас
+    public int ReadDWORD() => ReadInt32();
+    
+    // алиас
+    public int ReadWord() => ReadInt16();
 }

--- a/Utils/DateTimeHelper.cs
+++ b/Utils/DateTimeHelper.cs
@@ -1,0 +1,10 @@
+namespace QIParser.Utils;
+
+public class DateTimeHelper
+{
+    public static DateTime UnixTimeStampToDateTime(int unixTimeStamp)
+    {
+        var dateTime = new DateTime(1970, 1, 1);
+        return dateTime.AddSeconds(unixTimeStamp);
+    }
+}

--- a/Utils/DateTimeHelper.cs
+++ b/Utils/DateTimeHelper.cs
@@ -1,10 +1,11 @@
 namespace QIParser.Utils;
 
-public class DateTimeHelper
+public static class DateTimeHelper
 {
+    private static readonly DateTime UnixStart = new(1970, 1, 1);
+    
     public static DateTime UnixTimeStampToDateTime(int unixTimeStamp)
     {
-        var dateTime = new DateTime(1970, 1, 1);
-        return dateTime.AddSeconds(unixTimeStamp);
+        return UnixStart.AddSeconds(unixTimeStamp);
     }
 }


### PR DESCRIPTION
В ходе разбора бага был проведен небольшой рисерч, который показал, что форматы истории QIP 2010 и QIP Infium отличаются. Источник: https://github.com/CHERTS/im-history/blob/master/historytodbimport/im-format.txt
В рамках PR доработал метод чтения сообщения с учетом версии файла истории.
Проблемный файл истории, который воспроизводит баг, имеет версию истории "Неизвестно". Для этого типа экспериментальным путем подобрал метод -- двойную кодировку текста сообщения.
Ну и немного рефакторинга, как обычно.